### PR TITLE
refactor: ListAdapter 사용

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="BintrayJCenter" />
+      <option name="name" value="BintrayJCenter" />
+      <option name="url" value="https://jcenter.bintray.com/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://jitpack.io" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="Google" />
+      <option name="name" value="Google" />
+      <option name="url" value="https://dl.google.com/dl/android/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-kapt'
 
 android {
   compileSdkVersion 29
-  buildToolsVersion "29.0.2"
+  buildToolsVersion "29.0.3"
 
   defaultConfig {
     applicationId "com.foreknowledge.photomemo2"
@@ -34,12 +34,12 @@ dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
   implementation 'androidx.appcompat:appcompat:1.1.0'
-  implementation 'androidx.core:core-ktx:1.2.0'
+  implementation 'androidx.core:core-ktx:1.3.0'
   implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
   testImplementation 'junit:junit:4.13'
   androidTestImplementation 'androidx.test.ext:junit:1.1.1'
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-  implementation 'com.google.android.material:material:1.2.0-alpha06'
+  implementation 'com.google.android.material:material:1.3.0-alpha01'
   implementation 'androidx.exifinterface:exifinterface:1.2.0'
 
   // lifecycle

--- a/app/src/main/java/com/foreknowledge/photomemo2/adapter/BindingAdapter.kt
+++ b/app/src/main/java/com/foreknowledge/photomemo2/adapter/BindingAdapter.kt
@@ -1,6 +1,5 @@
 package com.foreknowledge.photomemo2.adapter
 
-import android.graphics.BitmapFactory
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.databinding.BindingAdapter
@@ -13,7 +12,7 @@ import com.bumptech.glide.Glide
 @BindingAdapter("bind_urlImage")
 fun ImageView.bindUrlImage(url: String?) {
     if (url == null) return
-    Glide.with(context)
+    Glide.with(this)
         .load(url.split(",")[0])
         .into(this)
 }
@@ -26,5 +25,7 @@ fun TextView.bindImagesCount(url: String?) {
 @BindingAdapter("bind_imagePath")
 fun ImageView.bindImagePath(path: String?) {
     if (path == null) return
-    setImageBitmap(BitmapFactory.decodeFile(path))
+    Glide.with(this)
+        .load(path)
+        .into(this)
 }

--- a/app/src/main/java/com/foreknowledge/photomemo2/adapter/MemoRecyclerAdapter.kt
+++ b/app/src/main/java/com/foreknowledge/photomemo2/adapter/MemoRecyclerAdapter.kt
@@ -1,5 +1,6 @@
 package com.foreknowledge.photomemo2.adapter
 
+import androidx.recyclerview.widget.DiffUtil
 import com.foreknowledge.photomemo2.R
 import com.foreknowledge.photomemo2.base.BaseRecyclerAdapter
 import com.foreknowledge.photomemo2.model.data.Memo
@@ -7,4 +8,14 @@ import com.foreknowledge.photomemo2.model.data.Memo
 /**
  * Create by Yeji on 22,April,2020.
  */
-class MemoRecyclerAdapter: BaseRecyclerAdapter<Memo>(R.layout.item_memo)
+class MemoRecyclerAdapter: BaseRecyclerAdapter<Memo>(R.layout.item_memo, diffCallback) {
+    companion object {
+        private val diffCallback = object: DiffUtil.ItemCallback<Memo>() {
+            override fun areItemsTheSame(oldItem: Memo, newItem: Memo) =
+                oldItem.id == newItem.id
+
+            override fun areContentsTheSame(oldItem: Memo, newItem: Memo) =
+                oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/java/com/foreknowledge/photomemo2/adapter/PhotoRecyclerAdapter.kt
+++ b/app/src/main/java/com/foreknowledge/photomemo2/adapter/PhotoRecyclerAdapter.kt
@@ -2,10 +2,11 @@ package com.foreknowledge.photomemo2.adapter
 
 import com.foreknowledge.photomemo2.R
 import com.foreknowledge.photomemo2.base.BaseRecyclerAdapter
+import com.foreknowledge.photomemo2.util.StringDiffCallback
 
 /**
  * Create by Yeji on 28,April,2020.
  */
-class PhotoRecyclerAdapter: BaseRecyclerAdapter<String>(R.layout.item_photo) {
-    fun getItemPosition(photoPath: String) = items.indexOf(photoPath)
+class PhotoRecyclerAdapter: BaseRecyclerAdapter<String>(R.layout.item_photo, StringDiffCallback()) {
+    fun getItemPosition(photoPath: String) = currentList.indexOf(photoPath)
 }

--- a/app/src/main/java/com/foreknowledge/photomemo2/adapter/PhotoViewPagerAdapter.kt
+++ b/app/src/main/java/com/foreknowledge/photomemo2/adapter/PhotoViewPagerAdapter.kt
@@ -3,7 +3,9 @@ package com.foreknowledge.photomemo2.adapter
 import android.content.Context
 import android.graphics.BitmapFactory
 import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.foreknowledge.photomemo2.util.StringDiffCallback
 import com.github.chrisbanes.photoview.PhotoView
 
 /**
@@ -11,28 +13,21 @@ import com.github.chrisbanes.photoview.PhotoView
  */
 class PhotoViewPagerAdapter(
     private val context: Context
-) : RecyclerView.Adapter<PhotoViewPagerAdapter.PhotoViewHolder>() {
-    private var items = listOf<String>()
+) : ListAdapter<String, PhotoViewPagerAdapter.PhotoViewHolder>(StringDiffCallback()) {
 
     inner class PhotoViewHolder(val view: PhotoView): RecyclerView.ViewHolder(view)
 
-    fun replaceItems(newItems: List<String>?) {
-        if (newItems != null) {
-            items = newItems
-            notifyDataSetChanged()
-        }
-    }
-
-    override fun getItemCount(): Int = items.size
+    fun replaceItems(newItems: List<String>) = submitList(newItems)
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PhotoViewHolder {
-        val photoView = PhotoView(context)
-        photoView.layoutParams = (ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT))
+        val photoView = PhotoView(context).apply {
+            layoutParams = ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+        }
 
         return PhotoViewHolder(photoView)
     }
 
     override fun onBindViewHolder(holder: PhotoViewHolder, position: Int) {
-        holder.view.setImageBitmap(BitmapFactory.decodeFile(items[position]))
+        holder.view.setImageBitmap(BitmapFactory.decodeFile(getItem(position)))
     }
 }

--- a/app/src/main/java/com/foreknowledge/photomemo2/adapter/PreviewRecyclerAdapter.kt
+++ b/app/src/main/java/com/foreknowledge/photomemo2/adapter/PreviewRecyclerAdapter.kt
@@ -1,9 +1,9 @@
 package com.foreknowledge.photomemo2.adapter
 
+import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.foreknowledge.photomemo2.MAX_IMAGE_COUNT
 import com.foreknowledge.photomemo2.R
-import com.foreknowledge.photomemo2.base.BaseRecyclerAdapter
 import com.foreknowledge.photomemo2.base.BaseViewHolder
 import com.foreknowledge.photomemo2.databinding.ItemPreviewBinding
 import com.foreknowledge.photomemo2.listener.OnItemClickListener
@@ -14,19 +14,13 @@ import com.foreknowledge.photomemo2.util.FileUtil
 /**
  * Create by Yeji on 27,April,2020.
  */
-class PreviewRecyclerAdapter
-	: BaseRecyclerAdapter<String>(R.layout.item_preview), OnItemMoveListener {
-	private val originalImgPaths: List<String> = items
+class PreviewRecyclerAdapter : RecyclerView.Adapter<BaseViewHolder<String>>(), OnItemMoveListener {
+	private val items = mutableListOf<String>()
 	private val actionHistory = mutableListOf<Action>()
 
 	private data class Action(val type: Int, val imagePath: String)
 
-	private var onItemDragListener: OnItemDragListener =
-		object : OnItemDragListener {
-			override fun onStartDrag(viewHolder: RecyclerView.ViewHolder) {
-				// default drag listener: do nothing
-			}
-		}
+	private var onItemDragListener: OnItemDragListener? = null
 
 	fun setOnItemDragListener(listener: (viewHolder: RecyclerView.ViewHolder) -> Unit) {
 		this.onItemDragListener = object : OnItemDragListener {
@@ -38,7 +32,7 @@ class PreviewRecyclerAdapter
 
 	fun getImages(): List<String> {
 		for (action in actionHistory)
-			if (action.type == DELETE_IMAGE)
+			if (action.type == FLAG_DELETE_IMAGE)
 				FileUtil.deleteFile(action.imagePath)
 
 		return items
@@ -46,21 +40,21 @@ class PreviewRecyclerAdapter
 
 	fun restoreImages(): List<String> {
 		for (action in actionHistory)
-			if (action.type == ADD_IMAGE)
+			if (action.type == FLAG_ADD_IMAGE)
 				FileUtil.deleteFile(action.imagePath)
 
-		return originalImgPaths
+		return items
 	}
 
 	fun addPath(path: String) {
-		actionHistory.add(Action(ADD_IMAGE, path))
+		actionHistory.add(Action(FLAG_ADD_IMAGE, path))
 		items.add(path)
 		notifyDataSetChanged()
 	}
 
 	fun addPaths(paths: List<String>) {
 		paths.forEach {
-			actionHistory.add(Action(ADD_IMAGE, it))
+			actionHistory.add(Action(FLAG_ADD_IMAGE, it))
 			items.add(it)
 		}
 		notifyDataSetChanged()
@@ -68,17 +62,22 @@ class PreviewRecyclerAdapter
 
 	fun isFull() = itemCount == MAX_IMAGE_COUNT
 
+	override fun getItemCount() = items.size
+
+	override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
+		object : BaseViewHolder<String>(R.layout.item_preview, parent) {}
+
 	override fun onBindViewHolder(holder: BaseViewHolder<String>, position: Int) {
 		holder.bind(items[position], object : OnItemClickListener<String>{
 			override fun onClick(item: String) {
-				actionHistory.add(Action(DELETE_IMAGE, item))
+				actionHistory.add(Action(FLAG_DELETE_IMAGE, item))
 				items.remove(item)
 				notifyDataSetChanged()
 			}
 		})
 
 		(holder.binding as ItemPreviewBinding).imagePreview.setOnLongClickListener {
-			onItemDragListener.onStartDrag(holder)
+			onItemDragListener?.onStartDrag(holder)
 			true
 		}
 	}
@@ -91,8 +90,15 @@ class PreviewRecyclerAdapter
 		notifyItemMoved(fromPosition, toPosition)
 	}
 
+	fun replaceItems(newItems: List<String>) {
+		items.clear()
+		items.addAll(newItems)
+		notifyDataSetChanged()
+	}
+
 	companion object {
-		const val ADD_IMAGE = 1
-		const val DELETE_IMAGE = -1
+		const val FLAG_ADD_IMAGE = 1
+		const val FLAG_DELETE_IMAGE = -1
 	}
 }
+

--- a/app/src/main/java/com/foreknowledge/photomemo2/base/BaseRecyclerAdapter.kt
+++ b/app/src/main/java/com/foreknowledge/photomemo2/base/BaseRecyclerAdapter.kt
@@ -2,7 +2,8 @@ package com.foreknowledge.photomemo2.base
 
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import com.foreknowledge.photomemo2.listener.OnItemClickListener
 import com.foreknowledge.photomemo2.listener.OnItemSingleClickListener
 
@@ -10,9 +11,9 @@ import com.foreknowledge.photomemo2.listener.OnItemSingleClickListener
  * Create by Yeji on 22,April,2020.
  */
 abstract class BaseRecyclerAdapter<T>(
-		@LayoutRes private val layoutResId: Int
-) : RecyclerView.Adapter<BaseViewHolder<T>>() {
-	protected val items = mutableListOf<T>()
+		@LayoutRes private val layoutResId: Int,
+		diffCallback: DiffUtil.ItemCallback<T>
+) : ListAdapter<T, BaseViewHolder<T>>(diffCallback) {
 
 	private var onItemClickListener: OnItemClickListener<T> =
 		object : OnItemClickListener<T> {
@@ -32,14 +33,8 @@ abstract class BaseRecyclerAdapter<T>(
 	override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
 		object : BaseViewHolder<T>(layoutResId, parent) {}
 
-	override fun getItemCount(): Int = items.size
-
-	open fun replaceItems(newItems: List<T>) {
-		items.clear()
-		items.addAll(newItems)
-		notifyDataSetChanged()
-	}
+	open fun replaceItems(newItems: List<T>) = submitList(newItems)
 
 	override fun onBindViewHolder(holder: BaseViewHolder<T>, position: Int) =
-		holder.bind(items[position], onItemClickListener)
+		holder.bind(getItem(position), onItemClickListener)
 }

--- a/app/src/main/java/com/foreknowledge/photomemo2/base/BaseRecyclerAdapter.kt
+++ b/app/src/main/java/com/foreknowledge/photomemo2/base/BaseRecyclerAdapter.kt
@@ -15,12 +15,7 @@ abstract class BaseRecyclerAdapter<T>(
 		diffCallback: DiffUtil.ItemCallback<T>
 ) : ListAdapter<T, BaseViewHolder<T>>(diffCallback) {
 
-	private var onItemClickListener: OnItemClickListener<T> =
-		object : OnItemClickListener<T> {
-			override fun onClick(item: T) {
-				// default click listener: do nothing
-			}
-		}
+	private var onItemClickListener: OnItemClickListener<T>? = null
 
 	open fun setOnItemClickListener(listener:(item: T) -> Unit) {
 		this.onItemClickListener = object : OnItemSingleClickListener<T>() {

--- a/app/src/main/java/com/foreknowledge/photomemo2/base/BaseRecyclerAdapter.kt
+++ b/app/src/main/java/com/foreknowledge/photomemo2/base/BaseRecyclerAdapter.kt
@@ -34,12 +34,10 @@ abstract class BaseRecyclerAdapter<T>(
 
 	override fun getItemCount(): Int = items.size
 
-	open fun replaceItems(newItems: List<T>?) {
-		if (newItems != null) {
-			items.clear()
-			items.addAll(newItems)
-			notifyDataSetChanged()
-		}
+	open fun replaceItems(newItems: List<T>) {
+		items.clear()
+		items.addAll(newItems)
+		notifyDataSetChanged()
 	}
 
 	override fun onBindViewHolder(holder: BaseViewHolder<T>, position: Int) =

--- a/app/src/main/java/com/foreknowledge/photomemo2/base/BaseViewHolder.kt
+++ b/app/src/main/java/com/foreknowledge/photomemo2/base/BaseViewHolder.kt
@@ -16,9 +16,9 @@ import com.foreknowledge.photomemo2.listener.OnItemClickListener
  */
 abstract class BaseViewHolder<T>(
 		@LayoutRes layoutResId: Int,
-		parent: ViewGroup?
-): RecyclerView.ViewHolder(
-		LayoutInflater.from(parent?.context).inflate(layoutResId, parent, false)
+		parent: ViewGroup
+) : RecyclerView.ViewHolder(
+		LayoutInflater.from(parent.context).inflate(layoutResId, parent, false)
 ) {
 	private val tag = javaClass.simpleName
 	val binding: ViewDataBinding = DataBindingUtil.bind(itemView)!!

--- a/app/src/main/java/com/foreknowledge/photomemo2/base/BaseViewHolder.kt
+++ b/app/src/main/java/com/foreknowledge/photomemo2/base/BaseViewHolder.kt
@@ -23,7 +23,7 @@ abstract class BaseViewHolder<T>(
 	private val tag = javaClass.simpleName
 	val binding: ViewDataBinding = DataBindingUtil.bind(itemView)!!
 
-	fun bind(item: T, listener: OnItemClickListener<T>) {
+	fun bind(item: T, listener: OnItemClickListener<T>?) {
 		try {
 			binding.run {
 				setVariable(BR.item, item)

--- a/app/src/main/java/com/foreknowledge/photomemo2/ui/CreateActivity.kt
+++ b/app/src/main/java/com/foreknowledge/photomemo2/ui/CreateActivity.kt
@@ -14,7 +14,10 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.ItemTouchHelper
-import com.foreknowledge.photomemo2.*
+import com.foreknowledge.photomemo2.EXTRA_MEMO_ID
+import com.foreknowledge.photomemo2.MAX_IMAGE_COUNT
+import com.foreknowledge.photomemo2.MSG_IMAGE_FULL
+import com.foreknowledge.photomemo2.R
 import com.foreknowledge.photomemo2.RequestCode.CHOOSE_CAMERA_IMAGE
 import com.foreknowledge.photomemo2.adapter.PreviewRecyclerAdapter
 import com.foreknowledge.photomemo2.base.BaseActivity
@@ -36,13 +39,12 @@ class CreateActivity : BaseActivity<ActivityCreateBinding>(R.layout.activity_cre
 		getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
 	}
 
-	private lateinit var itemTouchHelper: ItemTouchHelper
 	private val previewRecyclerAdapter = PreviewRecyclerAdapter()
 
 	override fun onCreate(savedInstanceState: Bundle?) {
 		super.onCreate(savedInstanceState)
 
-		itemTouchHelper = ItemTouchHelper(PreviewItemTouchCallback(previewRecyclerAdapter)).apply {
+		val itemTouchHelper = ItemTouchHelper(PreviewItemTouchCallback(previewRecyclerAdapter)).apply {
 			attachToRecyclerView(binding.previewRecyclerView)
 		}
 
@@ -75,14 +77,15 @@ class CreateActivity : BaseActivity<ActivityCreateBinding>(R.layout.activity_cre
 	}
 
 	private fun subscribeUI() = with(memoViewModel) {
-		currentMemo.observe(this@CreateActivity, Observer {
-			binding.item = it
-			it?.photoPaths?.run {
-				if (isNotBlank())
-					previewRecyclerAdapter.replaceItems(split(","))
+		val owner = this@CreateActivity
+		currentMemo.observe(owner, Observer { memo ->
+			binding.item = memo
+			memo?.photoPaths?.let {
+				if (it.isNotBlank())
+					previewRecyclerAdapter.replaceItems(it.split(","))
 			}
 		})
-		msg.observe(this@CreateActivity, Observer { ToastUtil.showToast(it) })
+		msg.observe(owner, Observer { ToastUtil.showToast(it) })
 	}
 
 	override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {

--- a/app/src/main/java/com/foreknowledge/photomemo2/ui/DetailActivity.kt
+++ b/app/src/main/java/com/foreknowledge/photomemo2/ui/DetailActivity.kt
@@ -54,14 +54,15 @@ class DetailActivity : BaseActivity<ActivityDetailBinding>(R.layout.activity_det
 	}
 
 	private fun subscribeUI() = with(viewModel) {
-		currentMemo.observe(this@DetailActivity, Observer {
-			binding.item = it
-			it?.photoPaths?.run {
-				if (isNotBlank())
-					photoRecyclerAdapter.replaceItems(split(","))
+		val owner = this@DetailActivity
+		currentMemo.observe(owner, Observer { memo ->
+			binding.item = memo
+			memo?.photoPaths?.let {
+				if (it.isNotBlank())
+					photoRecyclerAdapter.replaceItems(it.split(","))
 			}
 		})
-		msg.observe(this@DetailActivity, Observer { ToastUtil.showToast(it) })
+		msg.observe(owner, Observer { ToastUtil.showToast(it) })
 	}
 
 	private fun deleteMemo() = viewModel.currentMemo.value?.let { memo ->

--- a/app/src/main/java/com/foreknowledge/photomemo2/util/StringDiffCallback.kt
+++ b/app/src/main/java/com/foreknowledge/photomemo2/util/StringDiffCallback.kt
@@ -1,0 +1,12 @@
+package com.foreknowledge.photomemo2.util
+
+import androidx.recyclerview.widget.DiffUtil
+
+/**
+ * Create by Yeji on 12,June,2020.
+ */
+class StringDiffCallback : DiffUtil.ItemCallback<String>() {
+    override fun areItemsTheSame(oldItem: String, newItem: String) = oldItem == newItem
+
+    override fun areContentsTheSame(oldItem: String, newItem: String) = oldItem.contentEquals(newItem)
+}

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 22 01:40:59 KST 2020
+#Thu Jun 11 23:36:51 KST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
## 변경 사항

- 기존 BaseRecyclerAdapter에서 ListAdapter를 사용하도록 변경
  - BaseRecyclerAdapter를 상속한 RecyclerAdapter는 모두 ListAdapter를 사용하게 된다.
- PreviewRecyclerAdapter는 수정이 필요하기 때문에 내부 item을 변경할 수 없는 ListAdapter를 사용하지 못한다.
